### PR TITLE
fix upscaling crashing oculus HMDs

### DIFF
--- a/src/openvr/openvr_manager.cpp
+++ b/src/openvr/openvr_manager.cpp
@@ -23,11 +23,14 @@ namespace vrperfkit {
 			switch (inputFormat) {
 			case DXGI_FORMAT_R10G10B10A2_UNORM:
 			case DXGI_FORMAT_R10G10B10A2_TYPELESS:
-			case DXGI_FORMAT_R16G16B16A16_TYPELESS:
 				// SteamVR applies a different color conversion for these formats that we can't match
 				// with R8G8B8 textures, so we have to use a matching texture format for our own resources.
 				// Otherwise we'll get darkened pictures (applies to Revive mostly)
 				return DXGI_FORMAT_R10G10B10A2_UNORM;
+			case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+				// Same as above, for GTFO VR mod. 
+				// Oculus HMDs will return TextureUsesUnsupportedFormat if DXGI_FORMAT_R10G10B10A2_UNORM is used for this case.
+				return DXGI_FORMAT_R16G16B16A16_FLOAT;
 			default:
 				return DXGI_FORMAT_R8G8B8A8_UNORM;
 			}


### PR DESCRIPTION
### What

Certain output formats will result in a darkened output in SteamVR.
The previous commit 2ec4d0988d8ea453712e81e3cef6856d73a347cb adds `DXGI_FORMAT_R16G16B16A16_TYPELESS` to the list of input formats that should use the `DXGI_FORMAT_R10G10B10A2_UNORM` output format, resolving that issue.

Unfortunately, when using any Oculus HMD this will result in  `IVRCompositor009Hook_Submit` returning `VRCompositorError_TextureUsesUnsupportedFormat` when calling the original function.

### How

After reading https://github.com/ValveSoftware/openvr/issues/1409#issuecomment-658280470 I tried returning `DXGI_FORMAT_R16G16B16A16_FLOAT` instead, and the issue appears to be resolved, with no recurrence of the darkened output issue. 

Tested on `Oculus Quest (via Virtual Desktop )` and `Vive Pro`.

It is only used when the input format is `DXGI_FORMAT_R16G16B16A16_TYPELESS`